### PR TITLE
[130] Support for Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-javascript-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-javascript-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-javascript-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-javascript-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -5695,16 +5695,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -343,6 +343,22 @@ FusionAuthClient.prototype = {
   },
 
   /**
+   * Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   *
+   * @param {?UUIDString} messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+   * @param {MessageTemplateRequest} request The request object that contains all of the information used to create the message template.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  createMessageTemplate: function(messageTemplateId, request, callBack) {
+      return this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
+          .setJSONBody(request)
+          .post()
+          .go(callBack);
+  },
+
+  /**
    * Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    *
    * @param {?UUIDString} tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -704,6 +720,20 @@ FusionAuthClient.prototype = {
       return this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .delete()
+          .go(callBack);
+  },
+
+  /**
+   * Deletes the message template for the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to delete.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  deleteMessageTemplate: function(messageTemplateId, callBack) {
+      return this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .delete()
           .go(callBack);
   },
@@ -1455,6 +1485,22 @@ FusionAuthClient.prototype = {
       return this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .setJSONBody(request)
+          .patch()
+          .go(callBack);
+  },
+
+  /**
+   * Updates, via PATCH, the message template with the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains just the new message template information.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  patchMessageTemplate: function(messageTemplateId, request, callBack) {
+      return this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .setJSONBody(request)
           .patch()
           .go(callBack);
@@ -2289,6 +2335,32 @@ FusionAuthClient.prototype = {
           .urlParameter('applicationId', applicationId)
           .urlParameter('start', start)
           .urlParameter('end', end)
+          .get()
+          .go(callBack);
+  },
+
+  /**
+   * Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   *
+   * @param {?UUIDString} messageTemplateId (Optional) The Id of the message template.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  retrieveMessageTemplate: function(messageTemplateId, callBack) {
+      return this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
+          .get()
+          .go(callBack);
+  },
+
+  /**
+   * Retrieves all of the message templates.
+   *
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  retrieveMessageTemplates: function(callBack) {
+      return this._start()
+          .uri('/api/message/template')
           .get()
           .go(callBack);
   },
@@ -3265,6 +3337,22 @@ FusionAuthClient.prototype = {
       return this._start()
           .uri('/api/lambda')
           .urlSegment(lambdaId)
+          .setJSONBody(request)
+          .put()
+          .go(callBack);
+  },
+
+  /**
+   * Updates the message template with the given Id.
+   *
+   * @param {UUIDString} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains all of the new message template information.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  updateMessageTemplate: function(messageTemplateId, request, callBack) {
+      return this._start()
+          .uri('/api/message/template')
+          .urlSegment(messageTemplateId)
           .setJSONBody(request)
           .put()
           .go(callBack);
@@ -5607,16 +5695,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -5607,16 +5607,16 @@ var KeyUse = {
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [accessTokenPopulateId]
- * @property {UUIDString} [idTokenPopulateId]
- * @property {UUIDString} [samlv2PopulateId]
+ * @property {UUIDString} [reconcileId]
  */
 
 
 /**
  * @typedef {Object} LambdaConfiguration
  *
- * @property {UUIDString} [reconcileId]
+ * @property {UUIDString} [accessTokenPopulateId]
+ * @property {UUIDString} [idTokenPopulateId]
+ * @property {UUIDString} [samlv2PopulateId]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -2354,6 +2354,20 @@ FusionAuthClient.prototype = {
   },
 
   /**
+   * Creates a preview of the message template provided in the request, normalized to a given locale.
+   *
+   * @param {PreviewMessageTemplateRequest} request The request that contains the email template and optionally a locale to render it in.
+   * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
+   */
+  retrieveMessageTemplatePreview: function(request, callBack) {
+      return this._start()
+          .uri('/api/message/template/preview')
+          .setJSONBody(request)
+          .post()
+          .go(callBack);
+  },
+
+  /**
    * Retrieves all of the message templates.
    *
    * @param {Function} callBack The response handler call back. This function will be passed the ClientResponse object.
@@ -6024,6 +6038,17 @@ var LogoutBehavior = {
 
 
 /**
+ * An incredible simplified view of a message
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} Message
+ *
+ * @property {string} [text]
+ */
+
+
+/**
  * Stores an message template used to distribute messages;
  *
  * @author Michael Sleevi
@@ -6392,6 +6417,24 @@ var OAuthErrorType = {
  * @typedef {Object} PendingResponse
  *
  * @property {Array<User>} [users]
+ */
+
+
+/**
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} PreviewMessageTemplateRequest
+ *
+ * @property {string} [locale]
+ * @property {MessageTemplate} [messageTemplate]
+ */
+
+
+/**
+ * @typedef {Object} PreviewMessageTemplateResponse
+ *
+ * @property {Errors} [errors]
+ * @property {Message} [message]
  */
 
 

--- a/lib/FusionAuthClient.js
+++ b/lib/FusionAuthClient.js
@@ -5936,6 +5936,41 @@ var LogoutBehavior = {
 
 
 /**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} MessageTemplate
+ *
+ * @property {string} [defaultTemplate]
+ * @property {UUIDString} [id]
+ * @property {number} [insertInstant]
+ * @property {number} [lastUpdateInstant]
+ * @property {LocalizedStrings} [localizedTemplates]
+ * @property {string} [name]
+ */
+
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ *
+ * @typedef {Object} MessageTemplateRequest
+ *
+ * @property {MessageTemplate} [messageTemplate]
+ */
+
+
+/**
+ * @typedef {Object} MessageTemplateResponse
+ *
+ * @property {MessageTemplate} [messageTemplate]
+ * @property {Array<MessageTemplate>} [messageTemplates]
+ */
+
+
+/**
  * @typedef {Object} MetaData
  *
  * @property {DeviceInfo} [device]


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`